### PR TITLE
Refactor to allow for compilation

### DIFF
--- a/model.py
+++ b/model.py
@@ -344,7 +344,7 @@ class CausalSelfAttention(nn.Module):
             y = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=None, dropout_p=self.dropout if self.training else 0, is_causal=True)
         elif self.use_flex_attn and self.window_size is not None:
             block_mask = self.get_block_mask(T, x.device)
-            y = torch.nn.attention.flex_attention.flex_attention( q, k, v, block_mask=block_mask)
+            y = torch.nn.attention.flex_attention.flex_attention(q, k, v, block_mask=block_mask)
         else:
             if self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input"]:
                 num_bits = self.quantization_attn_dict["quantize_attn_act_qk_mult_q_input_bits"]

--- a/train.py
+++ b/train.py
@@ -645,7 +645,7 @@ class Trainer:
             print_model_tree(self.model, print_params=True)
 
         # Optimizer
-        self.scaler = torch.cuda.amp.GradScaler(enabled=(self.args.dtype == 'float16'))
+        self.scaler = torch.amp.GradScaler(self.device_type, enabled=(self.args.dtype == 'float16'))
         self.optimizer = self.model.configure_optimizers(self.args.weight_decay, self.args.learning_rate,
                                                          (self.args.beta1, self.args.beta2), self.device_type)
 


### PR DESCRIPTION
Seems flex attention works! However, it needs to be compiled to yield the benefits.

(Also appears that sliding window blocks will need to be in increments of 128 for now, and requires latest pytorch 2.5.0 or higher)

With these changes the memory utilization and speed are slightly better for flex attention (with smaller window) than flash attention, as expected, but again, only when compiled.